### PR TITLE
Simplify the Consumable instance

### DIFF
--- a/src/Data/Queue/Ephemeral.hs
+++ b/src/Data/Queue/Ephemeral.hs
@@ -20,7 +20,7 @@ data Queue a where
   deriving (Show)
 
 instance Consumable a => Consumable (Queue a) where
-  consume (Queue l m) = l `lseq` m `lseq` ()
+  consume (Queue l m) = ()
 
 empty :: (Queue a #-> Ur b) #-> Ur b
 empty k = k (Queue [] [])


### PR DESCRIPTION
You don't need the `lseq` pattern here, since the inner lists are unrestricted. This makes `consume` be O(1) instead of O(n).